### PR TITLE
Haversine distance

### DIFF
--- a/geo.cpp
+++ b/geo.cpp
@@ -2,6 +2,8 @@
 #include <math.h>
 
 const float earthR = 6371009;
+const float degToRad = 0.01745329251994;//M_PI / 180;
+const float radToDeg = 57.29577951308233;//180/M_PI
 Point::Point() 
 {
   set(0, 0);
@@ -47,22 +49,26 @@ float Point::bearing(Point* point)
   var Δλ = (lon2-lon1).toRadians();
   θ = atan2( sin Δλ ⋅ cos φ2 , cos φ1 ⋅ sin φ2 − sin φ1 ⋅ cos φ2 ⋅ cos Δλ )
   */
-  float f1 = this->latitude / 180.0 * M_PI;
-  float f2 = point->latitude / 180.0 * M_PI;
-  float dl = (point->longitude - this->longitude) / 180.0 * M_PI;
+  float f1 = this->latitude * degToRad;
+  float f2 = point->latitude * degToRad;
+  float dl = (point->longitude - this->longitude) * degToRad;
   float y = sin(dl) * cos(f2);
   float x = cos(f1) * sin(f2) - sin(f1) * cos(f2) * cos(dl);
   float rad = atan2(y,x);
-  return (rad > 0 ? rad : (2 * M_PI + rad)) * 180.0 / M_PI;
+  return (rad > 0 ? rad : (2 * M_PI + rad)) * radToDeg;
 }
 
 float Point::distance(const Point* point) const
 {
-  float f1 = this->latitude / 180.0 * M_PI;
-  float f2 = point->latitude / 180.0 * M_PI;
-  float dl = (point->longitude - this->longitude) / 180.0 * M_PI;
+  //Haversine formula from http://www.movable-type.co.uk/scripts/latlong.html
+  //a = sin²(Δφ/2) + cos φ1 ⋅ cos φ2 ⋅ sin²(Δλ/2)
+  //c = 2 ⋅ atan2( √a, √(1−a) )
+  //d = R ⋅ c
+  float f1 = this->latitude * degToRad;
+  float f2 = point->latitude * degToRad;
+  float dl = (point->longitude - this->longitude) * degToRad;
   float df = f2 - f1;
-  float a = sq(sin(df * 0.5)) + cos(f1) * cos(f2) * sq(sin(dl*0.5));
+  float a = sq(sin(df * 0.5)) + cos(f1) * cos(f2) * sq(sin(dl * 0.5));
   float c = 2 * atan2(sqrt(a), sqrt(1.0 - a));
   return earthR * c;
 }

--- a/geo.cpp
+++ b/geo.cpp
@@ -56,7 +56,7 @@ float Point::bearing(Point* point)
   return (rad > 0 ? rad : (2 * M_PI + rad)) * 180.0 / M_PI;
 }
 
-float Point::distance(Point)
+float Point::distance(const Point* point) const
 {
   float f1 = this->latitude / 180.0 * M_PI;
   float f2 = point->latitude / 180.0 * M_PI;

--- a/geo.cpp
+++ b/geo.cpp
@@ -1,6 +1,7 @@
 #include "geo.h"
 #include <math.h>
 
+const float earthR = 6371009;
 Point::Point() 
 {
   set(0, 0);
@@ -36,4 +37,32 @@ float Point::bearing(Point* point)
   return (rad > 0 ? rad : (2 * M_PI + rad)) * 180.0 / M_PI;
 }
 
+float Point::bearing(Point* point)
+{
+  /*
+  http://www.movable-type.co.uk/scripts/latlong.html
+  var φ1 = lat1.toRadians();
+  var φ2 = lat2.toRadians();
+  var Δφ = (lat2-lat1).toRadians();
+  var Δλ = (lon2-lon1).toRadians();
+  θ = atan2( sin Δλ ⋅ cos φ2 , cos φ1 ⋅ sin φ2 − sin φ1 ⋅ cos φ2 ⋅ cos Δλ )
+  */
+  float f1 = this->latitude / 180.0 * M_PI;
+  float f2 = point->latitude / 180.0 * M_PI;
+  float dl = (point->longitude - this->longitude) / 180.0 * M_PI;
+  float y = sin(dl) * cos(f2);
+  float x = cos(f1) * sin(f2) - sin(f1) * cos(f2) * cos(dl);
+  float rad = atan2(y,x);
+  return (rad > 0 ? rad : (2 * M_PI + rad)) * 180.0 / M_PI;
+}
 
+float Point::distance(Point)
+{
+  float f1 = this->latitude / 180.0 * M_PI;
+  float f2 = point->latitude / 180.0 * M_PI;
+  float dl = (point->longitude - this->longitude) / 180.0 * M_PI;
+  float df = f2 - f1;
+  float a = sq(sin(df * 0.5)) + cos(f1) * cos(f2) * sq(sin(dl*0.5));
+  float c = 2 * atan2(sqrt(a), sqrt(1.0 - a));
+  return earthR * c;
+}

--- a/geo.h
+++ b/geo.h
@@ -11,5 +11,7 @@ class Point
   void set(float lat, float lon) ;
   
   //Computes bearing from this to the specified point
-  float bearing(Point* point);  
+  float bearing(Point* point);
+  //Computes distance from this to the specified point in meters (accuracy %0.5)
+  float distance(const Point* point) const;
 };


### PR DESCRIPTION
@pavelbobov I think it is more common to have (long, lat), not (lat, long), as in (x, y). Maybe change the constructor?
